### PR TITLE
Add query to detect out-of-order cpp/linux privilege dropping

### DIFF
--- a/CodeQL_Queries/cpp/PrivilegeDropping/PrivilegeDroppingOutoforder.c
+++ b/CodeQL_Queries/cpp/PrivilegeDropping/PrivilegeDroppingOutoforder.c
@@ -1,0 +1,138 @@
+#include <stdlib.h>
+#include <sys/param.h>
+#include <unistd.h>
+#include <pwd.h>
+
+void callSetuidAndCheck(int uid) {
+    if (setuid(uid) != 0) {
+        exit(1);
+    }
+}
+
+void callSetgidAndCheck(int gid) {
+    if (setgid(gid) != 0) {
+        exit(1);
+    }
+}
+
+/// Correct ways to drop priv.
+
+void correctDropPrivInline() {
+    if (setgroups(0, NULL)) {
+        exit(1);
+    }
+
+    if (setgid(-2) != 0) {
+        exit(1);
+    }
+
+    if (setuid(-2) != 0) {
+        exit(1);
+    }
+}
+
+void correctDropPrivInScope() {
+    {
+        if (setgroups(0, NULL)) {
+            exit(1);
+        }
+    }
+
+    {
+        if (setgid(-2) != 0) {
+            exit(1);
+        }
+    }
+
+    {
+        if (setuid(-2) != 0) {
+            exit(1);
+        }
+    }
+}
+
+void correctOrderForInitgroups() {
+    struct passwd *pw = getpwuid(0);
+    if (pw) {
+        if (initgroups(pw->pw_name, -2)) {
+            exit(1);
+        }
+    } else {
+        // Unhandled.
+    }
+    int rc = setuid(-2);
+    if (rc) {
+        exit(1);
+    }
+}
+
+void correctDropPrivInScopeParent() {
+    {
+        callSetgidAndCheck(-2);
+    }
+    correctOrderForInitgroups();
+}
+
+void incorrectNoReturnCodeCheck() {
+    int user = -2;
+    if (user) {
+        if (user) {
+            int rc = setgid(user);
+            (void)rc;
+            initgroups("nobody", user);
+        }
+        if (user) {
+            setuid(user);
+        }
+    }
+}
+
+void correctDropPrivInFunctionCall() {
+    if (setgroups(0, NULL)) {
+        exit(1);
+    }
+
+    callSetgidAndCheck(-2);
+    callSetuidAndCheck(-2);
+}
+
+/// Incorrect, out of order gid and uid.
+/// Calling uid before gid will fail.
+
+void incorrectDropPrivOutOfOrderInline() {
+    if (setuid(-2) != 0) {
+        exit(1);
+    }
+
+    if (setgid(-2) != 0) {
+        exit(1);
+    }
+}
+
+void incorrectDropPrivOutOfOrderInScope() {
+    {
+        if (setuid(-2) != 0) {
+            exit(1);
+        }
+    }
+
+    setgid(-2);
+}
+
+void incorrectDropPrivOutOfOrderWithFunction() {
+    callSetuidAndCheck(-2);
+
+    if (setgid(-2) != 0) {
+        exit(1);
+    }
+}
+
+void incorrectDropPrivOutOfOrderWithFunction2() {
+    callSetuidAndCheck(-2);
+    callSetgidAndCheck(-2);
+}
+
+void incorrectDropPrivNoCheck() {
+    setgid(-2);
+    setuid(-2);
+}

--- a/CodeQL_Queries/cpp/PrivilegeDropping/PrivilegeDroppingOutoforder.qhelp
+++ b/CodeQL_Queries/cpp/PrivilegeDropping/PrivilegeDroppingOutoforder.qhelp
@@ -1,0 +1,35 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+<overview>
+<p>The code attempts to drop privilege in an incorrect order by
+erroneous dropping user privilege before groups. This has security
+impact if the return codes are not checked.</p>
+
+<p>False positives include code performing negative checks, making
+sure that setgid or setgroups does not work, meaning permissions are
+dropped. Additionally, other forms of sandboxing may be present removing
+any residual risk, for example a dedicated user namespace.</p>
+
+</overview>
+<recommendation>
+
+<p>Set the new group ID, then set the target user's intended groups by
+dropping previous supplemental source groups and initializing target
+groups, and finally set the target user.</p>
+
+</recommendation>
+<example>
+<p>The following example demonstrates out of order calls.</p>
+<sample src="PrivilegeDroppingOutoforder.c" />
+
+</example>
+<references>
+
+<li>CERT C Coding Standard:
+<a href="https://wiki.sei.cmu.edu/confluence/display/c/POS37-C.+Ensure+that+privilege+relinquishment+is+successful">POS37-C. Ensure that privilege relinquishment is successful</a>.
+</li>
+
+</references>
+</qhelp>

--- a/CodeQL_Queries/cpp/PrivilegeDropping/PrivilegeDroppingOutoforder.ql
+++ b/CodeQL_Queries/cpp/PrivilegeDropping/PrivilegeDroppingOutoforder.ql
@@ -13,100 +13,83 @@ import semmle.code.cpp.dataflow.TaintTracking
 class SetuidLikeFunctionCall extends FunctionCall {
   SetuidLikeFunctionCall() {
     // setuid/setresuid with the root user are false positives.
-    getTarget().getQualifiedName() = "setuid" or
-    getTarget().getQualifiedName() = "setresuid"
+    getTarget().hasGlobalName("setuid") or
+    getTarget().hasGlobalName("setresuid")
+  }
+}
+
+class SetuidLikeWrapperCall extends FunctionCall {
+  SetuidLikeFunctionCall baseCall;
+
+  SetuidLikeWrapperCall() {
+    this = baseCall or
+    exists(SetuidLikeWrapperCall fc |
+      this.getTarget() = fc.getEnclosingFunction() and
+      baseCall = fc.getBaseCall()
+    )
+  }
+
+  SetuidLikeFunctionCall getBaseCall() {
+    result = baseCall
   }
 }
 
 class CallBeforeSetuidFunctionCall extends FunctionCall {
   CallBeforeSetuidFunctionCall() {
     // setgid/setresgid with the root group are false positives.
-    getTarget().getQualifiedName() = "setgid" or
-    getTarget().getQualifiedName() = "setresgid" or
+    getTarget().hasGlobalName("setgid") or
+    getTarget().hasGlobalName("setresgid") or
     // Compatibility may require skipping initgroups and setgroups return checks.
     // A stricter best practice is to check the result and errnor for EPERM.
-    getTarget().getQualifiedName() = "initgroups" or
-    getTarget().getQualifiedName() = "setgroups" or
+    getTarget().hasGlobalName("initgroups") or
+    getTarget().hasGlobalName("setgroups") or
     // Find variants of CVE-2017-11747 where the low-priv user can stop the process.
     // Feel free to extend this with other variants.
-    getTarget().getQualifiedName() = "pidfile_create"
-  }
-
-  predicate isCalledAfter(SetuidLikeFunctionCall fc) {
-    exists(ControlFlowNode cfn |
-        cfn = this.getAPredecessor+() or
-        // Expressions before enclosing function.
-        cfn = callerPredecessor(this.getEnclosingFunction().getACallToThisFunction()) |
-        fc = calls(cfn, this)
-    )
-  }
-
-  private FunctionCall calls(ControlFlowNode cfn, FunctionCall guard) {
-    result = controlFlowElementIs(cfn) or
-    result = controlFlowElementContains(cfn, guard) or
-    result = controlFlowElementCalls(cfn, guard)
-  }
-
-  private predicate callsSelf(ControlFlowNode cfn, ControlFlowNode caller) {
-    cfn = caller or
-    exists (ControlFlowNode subnode |
-        subnode = cfn.(Block).getAChild+() or
-        subnode = cfn.(FunctionCall).getTarget().getBlock().getAChild+() |
-        subnode = caller or callsSelf(subnode, caller)
-    )
-  }
-
-  private ControlFlowNode callerPredecessor(ControlFlowNode caller) {
-    exists(ControlFlowNode cfn |
-      cfn = caller.getEnclosingStmt().getAPredecessor+() |
-      not callsSelf(cfn, caller) and
-      result = cfn
-    )
-  }
-
-  private FunctionCall controlFlowElementContains(ControlFlowNode cfn, FunctionCall guard) {
-    guard.getBasicBlock() != cfn.getBasicBlock() and
-    exists (ControlFlowNode subnode |
-      subnode = cfn.getBasicBlock().getANode+() |
-      result = calls(subnode, guard)
-    )
-  }
-
-  private FunctionCall controlFlowElementCalls(ControlFlowNode cfn, FunctionCall guard) {
-    exists(ControlFlowNode subnode |
-      subnode = cfn.(FunctionCall).getTarget().getBlock().getAChild+() |
-      result = calls(subnode, guard)
-    )
-  }
-
-  private FunctionCall controlFlowElementIs(SetuidLikeFunctionCall cfn) {
-    result = cfn
+    getTarget().hasGlobalName("pidfile_create")
   }
 }
 
-predicate withinCondition(Expr t) {
-  exists(Expr src | src = t.getParent+() | src.isCondition()) or t.isCondition()
+class CallBeforeSetuidWrapperCall extends FunctionCall {
+  CallBeforeSetuidFunctionCall baseCall;
+
+  CallBeforeSetuidWrapperCall() {
+    this = baseCall or
+    exists(CallBeforeSetuidWrapperCall fc |
+      this.getTarget() = fc.getEnclosingFunction() and
+      baseCall = fc.getBaseCall()
+    )
+  }
+
+  CallBeforeSetuidFunctionCall getBaseCall() {
+    result = baseCall
+  }
+}
+
+predicate setuidBeforeSetgid(
+    SetuidLikeWrapperCall setuidWrapper,
+    CallBeforeSetuidWrapperCall setgidWrapper) {
+  setgidWrapper.getAPredecessor+() = setuidWrapper
 }
 
 predicate flowsToCondition(Expr fc) {
   exists(DataFlow::Node source, DataFlow::Node sink |
     TaintTracking::localTaint(source, sink) and
     fc = source.asExpr() and
-    withinCondition(sink.asExpr())
+    (sink.asExpr().getParent*().(ControlFlowNode).isCondition() or sink.asExpr().isCondition())
   )
 }
 
 from
-  CallBeforeSetuidFunctionCall func,
-  Function funcParent,
+  Function func,
+  CallBeforeSetuidFunctionCall fc,
   SetuidLikeFunctionCall setuid
 where
-  func.isCalledAfter(setuid) and
+  setuidBeforeSetgid(setuid, fc) and
   // Require the call return code to be used in a condition.
   // This introduces false negatives where the return is checked but then
   // errno == EPERM allows execution to continue.
-  (not flowsToCondition(func) or not flowsToCondition(setuid)) and
-  funcParent = func.getEnclosingFunction()
-select func, "This function is called within " + funcParent + ", and potentially after " +
+  (not flowsToCondition(fc) or not flowsToCondition(setuid)) and
+  func = fc.getEnclosingFunction()
+select fc, "This function is called within " + func + ", and potentially after " +
   "setuid/setresuid, and may not succeed. Be sure to check the return code and errno",
   setuid

--- a/CodeQL_Queries/cpp/PrivilegeDropping/PrivilegeDroppingOutoforder.ql
+++ b/CodeQL_Queries/cpp/PrivilegeDropping/PrivilegeDroppingOutoforder.ql
@@ -1,0 +1,112 @@
+/**
+ * @name PrivilegeDroppingOutoforder
+ * @kind problem
+ * @problem.severity recommendation
+ * @id cpp/drop-permissions-outoforder
+ * @tags security
+ *       external/cwe/cwe-273
+ */
+
+import cpp
+import semmle.code.cpp.dataflow.TaintTracking
+
+class SetuidLikeFunctionCall extends FunctionCall {
+  SetuidLikeFunctionCall() {
+    // setuid/setresuid with the root user are false positives.
+    getTarget().getQualifiedName() = "setuid" or
+    getTarget().getQualifiedName() = "setresuid"
+  }
+}
+
+class CallBeforeSetuidFunctionCall extends FunctionCall {
+  CallBeforeSetuidFunctionCall() {
+    // setgid/setresgid with the root group are false positives.
+    getTarget().getQualifiedName() = "setgid" or
+    getTarget().getQualifiedName() = "setresgid" or
+    // Compatibility may require skipping initgroups and setgroups return checks.
+    // A stricter best practice is to check the result and errnor for EPERM.
+    getTarget().getQualifiedName() = "initgroups" or
+    getTarget().getQualifiedName() = "setgroups" or
+    // Find variants of CVE-2017-11747 where the low-priv user can stop the process.
+    // Feel free to extend this with other variants.
+    getTarget().getQualifiedName() = "pidfile_create"
+  }
+
+  predicate isCalledAfter(SetuidLikeFunctionCall fc) {
+    exists(ControlFlowNode cfn |
+        cfn = this.getAPredecessor+() or
+        // Expressions before enclosing function.
+        cfn = callerPredecessor(this.getEnclosingFunction().getACallToThisFunction()) |
+        fc = calls(cfn, this)
+    )
+  }
+
+  private FunctionCall calls(ControlFlowNode cfn, FunctionCall guard) {
+    result = controlFlowElementIs(cfn) or
+    result = controlFlowElementContains(cfn, guard) or
+    result = controlFlowElementCalls(cfn, guard)
+  }
+
+  private predicate callsSelf(ControlFlowNode cfn, ControlFlowNode caller) {
+    cfn = caller or
+    exists (ControlFlowNode subnode |
+        subnode = cfn.(Block).getAChild+() or
+        subnode = cfn.(FunctionCall).getTarget().getBlock().getAChild+() |
+        subnode = caller or callsSelf(subnode, caller)
+    )
+  }
+
+  private ControlFlowNode callerPredecessor(ControlFlowNode caller) {
+    exists(ControlFlowNode cfn |
+      cfn = caller.getEnclosingStmt().getAPredecessor+() |
+      not callsSelf(cfn, caller) and
+      result = cfn
+    )
+  }
+
+  private FunctionCall controlFlowElementContains(ControlFlowNode cfn, FunctionCall guard) {
+    guard.getBasicBlock() != cfn.getBasicBlock() and
+    exists (ControlFlowNode subnode |
+      subnode = cfn.getBasicBlock().getANode+() |
+      result = calls(subnode, guard)
+    )
+  }
+
+  private FunctionCall controlFlowElementCalls(ControlFlowNode cfn, FunctionCall guard) {
+    exists(ControlFlowNode subnode |
+      subnode = cfn.(FunctionCall).getTarget().getBlock().getAChild+() |
+      result = calls(subnode, guard)
+    )
+  }
+
+  private FunctionCall controlFlowElementIs(SetuidLikeFunctionCall cfn) {
+    result = cfn
+  }
+}
+
+predicate withinCondition(Expr t) {
+  exists(Expr src | src = t.getParent+() | src.isCondition()) or t.isCondition()
+}
+
+predicate flowsToCondition(Expr fc) {
+  exists(DataFlow::Node source, DataFlow::Node sink |
+    TaintTracking::localTaint(source, sink) and
+    fc = source.asExpr() and
+    withinCondition(sink.asExpr())
+  )
+}
+
+from
+  CallBeforeSetuidFunctionCall func,
+  Function funcParent,
+  SetuidLikeFunctionCall setuid
+where
+  func.isCalledAfter(setuid) and
+  // Require the call return code to be used in a condition.
+  // This introduces false negatives where the return is checked but then
+  // errno == EPERM allows execution to continue.
+  (not flowsToCondition(func) or not flowsToCondition(setuid)) and
+  funcParent = func.getEnclosingFunction()
+select func, "This function is called within " + funcParent + ", and potentially after " +
+  "setuid/setresuid, and may not succeed. Be sure to check the return code and errno",
+  setuid


### PR DESCRIPTION
Hi folks, I am working on this query (my first!) to detect usage of `setuid` before `setgid`, `initgroups`, etc and when error checking is missing. This situation indicates an attempt to drop privileges incorrectly, and the most important part of the bug is the lack of error handling. This would effect setuid/setgid-bit executables and daemons run as root with the intention to later dropping privileges. I added inline comments about my thoughts on false positives and false negatives.

I think this category of checks can be extended, for example another query can be added to find instances where `initgroups` or `setgroups` (dropping supplemental groups) are missing or where capabilities are not dropped, etc. For this reason I created a subfolder for the query, test code, and helpfile.

I tried to create the small set of test cases to improve accuracy. I also browsed GitHub for about 100 projects that may be impacted, by looking for usage of `setuid`. At this point I am mildly confident this is working as intended. But this is my first time using CodeQL and I am sure it could use a lot of feedback. On my mind are: is this performance enough, am I using the QL stdlib correctly, can I simplify the logic, is there a way to test it on a larger set of projects?
