### PR TITLE
optimization debian package manager tweaks

### DIFF
--- a/SecurityExploits/Ansible/fetch_CVE-2019-3828/server/Dockerfile
+++ b/SecurityExploits/Ansible/fetch_CVE-2019-3828/server/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 
 RUN apt-get update && \
-    apt-get --no-install-recommends install -y \
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates \
       ansible git curl zip unzip psmisc \
       tmux sudo emacs openssh-server net-tools \
       gcc

--- a/SecurityExploits/Ansible/fetch_CVE-2019-3828/server/Dockerfile
+++ b/SecurityExploits/Ansible/fetch_CVE-2019-3828/server/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get --no-install-recommends install -y \
       ansible git curl zip unzip psmisc \
       tmux sudo emacs openssh-server net-tools \
       gcc

--- a/SecurityExploits/Ansible/fetch_CVE-2019-3828/zeuss/Dockerfile
+++ b/SecurityExploits/Ansible/fetch_CVE-2019-3828/zeuss/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 
 RUN apt-get update && \
-    apt-get --no-install-recommends install -y \
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates \
       git curl zip unzip psmisc \
       tmux sudo emacs openssh-server net-tools x11-apps \
       build-essential libssl-dev libffi-dev python-dev \

--- a/SecurityExploits/Ansible/fetch_CVE-2019-3828/zeuss/Dockerfile
+++ b/SecurityExploits/Ansible/fetch_CVE-2019-3828/zeuss/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get --no-install-recommends install -y \
       git curl zip unzip psmisc \
       tmux sudo emacs openssh-server net-tools x11-apps \
       build-essential libssl-dev libffi-dev python-dev \

--- a/SecurityExploits/Apache/Struts/CVE-2018-11776/struts-attacker/Dockerfile
+++ b/SecurityExploits/Apache/Struts/CVE-2018-11776/struts-attacker/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 
 RUN apt-get update && \
-    apt-get --no-install-recommends install -y curl tmux emacs net-tools gcc ssh build-essential
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates curl tmux emacs net-tools gcc ssh build-essential
 
 # Create user account for the attacker.
 RUN adduser attacker --disabled-password

--- a/SecurityExploits/Apache/Struts/CVE-2018-11776/struts-attacker/Dockerfile
+++ b/SecurityExploits/Apache/Struts/CVE-2018-11776/struts-attacker/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 
 RUN apt-get update && \
-    apt-get install -y curl tmux emacs net-tools gcc ssh build-essential
+    apt-get --no-install-recommends install -y curl tmux emacs net-tools gcc ssh build-essential
 
 # Create user account for the attacker.
 RUN adduser attacker --disabled-password

--- a/SecurityExploits/Apache/Struts/CVE-2018-11776/struts-server/Dockerfile
+++ b/SecurityExploits/Apache/Struts/CVE-2018-11776/struts-server/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get --no-install-recommends install -y \
       openjdk-8-jdk git curl zip unzip \
       tmux sudo emacs maven openssh-server net-tools x11-apps
 

--- a/SecurityExploits/Apache/Struts/CVE-2018-11776/struts-server/Dockerfile
+++ b/SecurityExploits/Apache/Struts/CVE-2018-11776/struts-server/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 
 RUN apt-get update && \
-    apt-get --no-install-recommends install -y \
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates \
       openjdk-8-jdk git curl zip unzip \
       tmux sudo emacs maven openssh-server net-tools x11-apps
 

--- a/SecurityExploits/CImg/Dockerfile
+++ b/SecurityExploits/CImg/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 
 RUN apt-get update && \
-    apt-get install -y git gcc build-essential curl
+    apt-get --no-install-recommends install -y git gcc build-essential curl
 
 # Create user account for the attacker.
 RUN adduser semmle --disabled-password

--- a/SecurityExploits/CImg/Dockerfile
+++ b/SecurityExploits/CImg/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 
 RUN apt-get update && \
-    apt-get --no-install-recommends install -y git gcc build-essential curl
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates git gcc build-essential curl
 
 # Create user account for the attacker.
 RUN adduser semmle --disabled-password

--- a/SecurityExploits/Facebook/Fizz/CVE-2019-3560/attacker/Dockerfile
+++ b/SecurityExploits/Facebook/Fizz/CVE-2019-3560/attacker/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get --no-install-recommends install -y \
       sudo tmux screen emacs git gdb net-tools g++ cmake \
       libboost-all-dev libevent-dev libdouble-conversion-dev \
       libgoogle-glog-dev libgflags-dev libiberty-dev liblz4-dev \

--- a/SecurityExploits/Facebook/Fizz/CVE-2019-3560/attacker/Dockerfile
+++ b/SecurityExploits/Facebook/Fizz/CVE-2019-3560/attacker/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 
 RUN apt-get update && \
-    apt-get --no-install-recommends install -y \
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates \
       sudo tmux screen emacs git gdb net-tools g++ cmake \
       libboost-all-dev libevent-dev libdouble-conversion-dev \
       libgoogle-glog-dev libgflags-dev libiberty-dev liblz4-dev \

--- a/SecurityExploits/Facebook/Fizz/CVE-2019-3560/server/Dockerfile
+++ b/SecurityExploits/Facebook/Fizz/CVE-2019-3560/server/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get --no-install-recommends install -y \
       sudo tmux screen emacs git gdb net-tools g++ cmake \
       libboost-all-dev libevent-dev libdouble-conversion-dev \
       libgoogle-glog-dev libgflags-dev libiberty-dev liblz4-dev \

--- a/SecurityExploits/Facebook/Fizz/CVE-2019-3560/server/Dockerfile
+++ b/SecurityExploits/Facebook/Fizz/CVE-2019-3560/server/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 
 RUN apt-get update && \
-    apt-get --no-install-recommends install -y \
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates \
       sudo tmux screen emacs git gdb net-tools g++ cmake \
       libboost-all-dev libevent-dev libdouble-conversion-dev \
       libgoogle-glog-dev libgflags-dev libiberty-dev liblz4-dev \

--- a/SecurityExploits/libssh2/out_of_bounds_read_disconnect_CVE-2019-17498/client/Dockerfile
+++ b/SecurityExploits/libssh2/out_of_bounds_read_disconnect_CVE-2019-17498/client/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 
 RUN apt-get update && \
-    apt-get --no-install-recommends install -y \
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates \
       sudo tmux screen emacs git gdb net-tools psmisc \
       build-essential autoconf automake libtool g++ \
       libssl-dev

--- a/SecurityExploits/libssh2/out_of_bounds_read_disconnect_CVE-2019-17498/client/Dockerfile
+++ b/SecurityExploits/libssh2/out_of_bounds_read_disconnect_CVE-2019-17498/client/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get --no-install-recommends install -y \
       sudo tmux screen emacs git gdb net-tools psmisc \
       build-essential autoconf automake libtool g++ \
       libssl-dev

--- a/SecurityExploits/libssh2/out_of_bounds_read_disconnect_CVE-2019-17498/server/Dockerfile
+++ b/SecurityExploits/libssh2/out_of_bounds_read_disconnect_CVE-2019-17498/server/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get --no-install-recommends install -y \
       sudo tmux screen emacs git gdb net-tools psmisc \
       build-essential autoconf g++ netcat
 

--- a/SecurityExploits/libssh2/out_of_bounds_read_disconnect_CVE-2019-17498/server/Dockerfile
+++ b/SecurityExploits/libssh2/out_of_bounds_read_disconnect_CVE-2019-17498/server/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 
 RUN apt-get update && \
-    apt-get --no-install-recommends install -y \
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates \
       sudo tmux screen emacs git gdb net-tools psmisc \
       build-essential autoconf g++ netcat
 

--- a/SecurityExploits/libssh2/out_of_bounds_read_kex_CVE-2019-13115/client/Dockerfile
+++ b/SecurityExploits/libssh2/out_of_bounds_read_kex_CVE-2019-13115/client/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 
 RUN apt-get update && \
-    apt-get --no-install-recommends install -y \
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates \
       sudo tmux screen emacs git gdb net-tools psmisc \
       build-essential autoconf automake libtool g++ \
       libssl-dev

--- a/SecurityExploits/libssh2/out_of_bounds_read_kex_CVE-2019-13115/client/Dockerfile
+++ b/SecurityExploits/libssh2/out_of_bounds_read_kex_CVE-2019-13115/client/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get --no-install-recommends install -y \
       sudo tmux screen emacs git gdb net-tools psmisc \
       build-essential autoconf automake libtool g++ \
       libssl-dev

--- a/SecurityExploits/libssh2/out_of_bounds_read_kex_CVE-2019-13115/server/Dockerfile
+++ b/SecurityExploits/libssh2/out_of_bounds_read_kex_CVE-2019-13115/server/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 
 RUN apt-get update && \
-    apt-get --no-install-recommends install -y \
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates \
       sudo tmux screen emacs git gdb net-tools psmisc \
       build-essential autoconf g++ \
       libssl-dev zlib1g-dev

--- a/SecurityExploits/libssh2/out_of_bounds_read_kex_CVE-2019-13115/server/Dockerfile
+++ b/SecurityExploits/libssh2/out_of_bounds_read_kex_CVE-2019-13115/server/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get --no-install-recommends install -y \
       sudo tmux screen emacs git gdb net-tools psmisc \
       build-essential autoconf g++ \
       libssl-dev zlib1g-dev

--- a/SecurityExploits/rsyslog/CVE-2018-1000140_snprintf_librelp/Dockerfile
+++ b/SecurityExploits/rsyslog/CVE-2018-1000140_snprintf_librelp/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:artful
 
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get --no-install-recommends install -y \
       sudo tmux screen emacs git gdb net-tools \
       python python3 build-essential gcc \
       cmake bison flex libprotobuf-c-dev libreadline-dev libsqlite3-dev \

--- a/SecurityExploits/rsyslog/CVE-2018-1000140_snprintf_librelp/Dockerfile
+++ b/SecurityExploits/rsyslog/CVE-2018-1000140_snprintf_librelp/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:artful
 
 RUN apt-get update && \
-    apt-get --no-install-recommends install -y \
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates \
       sudo tmux screen emacs git gdb net-tools \
       python python3 build-essential gcc \
       cmake bison flex libprotobuf-c-dev libreadline-dev libsqlite3-dev \

--- a/SecurityExploits/strongSwan/CVE-2018-5388/Dockerfile
+++ b/SecurityExploits/strongSwan/CVE-2018-5388/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:artful
 
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get --no-install-recommends install -y \
       openjdk-8-jdk git-core gnupg flex bison gperf build-essential \
       zip curl zlib1g-dev gcc-multilib g++-multilib libc6-dev-i386 \
       lib32ncurses5-dev x11proto-core-dev libx11-dev lib32z-dev ccache \

--- a/SecurityExploits/strongSwan/CVE-2018-5388/Dockerfile
+++ b/SecurityExploits/strongSwan/CVE-2018-5388/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:artful
 
 RUN apt-get update && \
-    apt-get --no-install-recommends install -y \
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates \
       openjdk-8-jdk git-core gnupg flex bison gperf build-essential \
       zip curl zlib1g-dev gcc-multilib g++-multilib libc6-dev-i386 \
       lib32ncurses5-dev x11proto-core-dev libx11-dev lib32z-dev ccache \

--- a/SecurityExploits/vivo-project/CVE-2019-6986/vivo-attacker/Dockerfile
+++ b/SecurityExploits/vivo-project/CVE-2019-6986/vivo-attacker/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 
 RUN apt-get update && \
-    apt-get install -y curl tmux emacs net-tools ssh sudo
+    apt-get --no-install-recommends install -y curl tmux emacs net-tools ssh sudo
 
 # Create user account for the attacker.
 RUN adduser attacker --disabled-password

--- a/SecurityExploits/vivo-project/CVE-2019-6986/vivo-attacker/Dockerfile
+++ b/SecurityExploits/vivo-project/CVE-2019-6986/vivo-attacker/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 
 RUN apt-get update && \
-    apt-get --no-install-recommends install -y curl tmux emacs net-tools ssh sudo
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates curl tmux emacs net-tools ssh sudo
 
 # Create user account for the attacker.
 RUN adduser attacker --disabled-password

--- a/SecurityExploits/vivo-project/CVE-2019-6986/vivo-server/Dockerfile
+++ b/SecurityExploits/vivo-project/CVE-2019-6986/vivo-server/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get --no-install-recommends install -y \
       maven git curl wget zip unzip mysql-server \
       tmux sudo emacs maven openssh-server net-tools x11-apps \
       default-jdk openjdk-11-dbg

--- a/SecurityExploits/vivo-project/CVE-2019-6986/vivo-server/Dockerfile
+++ b/SecurityExploits/vivo-project/CVE-2019-6986/vivo-server/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 
 RUN apt-get update && \
-    apt-get --no-install-recommends install -y \
+    apt-get --no-install-recommends  install -y apt-utils ca-certificates \
       maven git curl wget zip unzip mysql-server \
       tmux sudo emacs maven openssh-server net-tools x11-apps \
       default-jdk openjdk-11-dbg


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>