### PR TITLE
OpenSSL hostname verification bug hunting queries

### DIFF
--- a/CodeQL_Queries/cpp/OpenSSL-hostname-validation/BoostAsioMissingVerifyCallback.ql
+++ b/CodeQL_Queries/cpp/OpenSSL-hostname-validation/BoostAsioMissingVerifyCallback.ql
@@ -1,0 +1,81 @@
+/**
+ * @name BoostAsioMissingVerifyCallback
+ * @kind problem
+ * @problem.severity recommendation
+ * @id cpp/boost-asio-missing-boost-verify-callback
+ * @tags security
+ *       external/cwe/cwe-273
+ *
+ * The default `verify_callback` https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_verify.html
+ * does not compare CN/hostnames so a TLS client can be MITMed.
+ *
+ * The boost ASIO/SSL library also does not install a hostname verifier callback.
+ *
+ * False positives include intentionally skipping checking (for example as the result of
+ * configuration), using a server context, or using an uncommon strategy for inspecting certs.
+ */
+
+import cpp
+
+predicate sslOrDetailNamespace(Namespace n) {
+  n.getQualifiedName() = "boost::asio::ssl" or
+  n.getQualifiedName() = "boost::asio::ssl::detail"
+}
+
+predicate sslStreamOrEngineType(UserType t) {
+  t.getSimpleName() = "stream" or
+  t.getSimpleName() = "engine" or
+  t.getSimpleName() = "context"
+}
+
+class AsioStreamType extends Type {
+  Type baseType;
+
+  AsioStreamType() {
+    (
+      // Consider shared_ptr, raw pointers, or base types.
+      baseType = this.(DerivedType).getBaseType() or
+      baseType = this.(UserType).getATemplateArgument+() or
+      baseType = this
+    ) and
+    sslOrDetailNamespace(baseType.(UserType).getNamespace()) and
+    sslStreamOrEngineType(baseType)
+  }
+}
+
+class StreamSocketVariable extends Variable {
+  AsioStreamType type;
+
+  StreamSocketVariable() { this.getType() = type }
+}
+
+class SetVerifyModeFunctionCall extends FunctionCall {
+  SetVerifyModeFunctionCall() {
+    // This can be improved, false positives can be reduced by also checking namespace.
+    this.getTarget().hasName("set_verify_mode")
+  }
+}
+
+class SetVerifyCallbackFunctionCall extends FunctionCall {
+  SetVerifyCallbackFunctionCall() {
+    // This can be improved, false positives can be reduced by also checking namespace.
+    this.getTarget().hasName("set_verify_callback")
+  }
+}
+
+predicate callsSetVerifyCallback(StreamSocketVariable v) {
+  exists(SetVerifyCallbackFunctionCall fc, Expr e |
+    e = fc.getAChild() and
+    v = e.(VariableAccess).getTarget()
+  )
+}
+
+from SetVerifyModeFunctionCall fc, StreamSocketVariable v
+where
+  // There is most likely a better method than assuming the only namespace/simple-name
+  // child access is the qualifier.
+  v = fc.getAChild().(VariableAccess).getTarget() and
+  not callsSetVerifyCallback(v)
+select v,
+  "boost::asio::ssl context calls set_verify_mode without a callback, " +
+    " if this is a client context then hostname validation may be missing", fc

--- a/CodeQL_Queries/cpp/OpenSSL-hostname-validation/BoostAsioMissingVerifyCallback.ql
+++ b/CodeQL_Queries/cpp/OpenSSL-hostname-validation/BoostAsioMissingVerifyCallback.ql
@@ -5,7 +5,9 @@
  * @id cpp/boost-asio-missing-boost-verify-callback
  * @tags security
  *       external/cwe/cwe-273
- *
+ */
+
+/*
  * The default `verify_callback` https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_verify.html
  * does not compare CN/hostnames so a TLS client can be MITMed.
  *
@@ -65,7 +67,7 @@ class SetVerifyCallbackFunctionCall extends FunctionCall {
 
 predicate callsSetVerifyCallback(StreamSocketVariable v) {
   exists(SetVerifyCallbackFunctionCall fc, Expr e |
-    e = fc.getAChild() and
+    e = fc.getQualifier() and
     v = e.(VariableAccess).getTarget()
   )
 }
@@ -74,8 +76,8 @@ from SetVerifyModeFunctionCall fc, StreamSocketVariable v
 where
   // There is most likely a better method than assuming the only namespace/simple-name
   // child access is the qualifier.
-  v = fc.getAChild().(VariableAccess).getTarget() and
+  v = fc.getQualifier().(VariableAccess).getTarget() and
   not callsSetVerifyCallback(v)
-select v,
-  "boost::asio::ssl context calls set_verify_mode without a callback, " +
-    " if this is a client context then hostname validation may be missing", fc
+select fc,
+  "boost::asio::ssl context calls set_verify_mode without a callback $@, if this is a client context then hostname validation may be missing",
+  v, "on the socket (" + v + ")"

--- a/CodeQL_Queries/cpp/OpenSSL-hostname-validation/BoostAsioMissingVerifyCallback.ql
+++ b/CodeQL_Queries/cpp/OpenSSL-hostname-validation/BoostAsioMissingVerifyCallback.ql
@@ -80,4 +80,4 @@ where
   not callsSetVerifyCallback(v)
 select fc,
   "boost::asio::ssl context calls set_verify_mode without a callback $@, if this is a client context then hostname validation may be missing",
-  v, "on the socket (" + v + ")"
+  v, "on the socket (" + v.getName() + ")"

--- a/CodeQL_Queries/cpp/OpenSSL-hostname-validation/OpenSSLMissingVerifyCallback.ql
+++ b/CodeQL_Queries/cpp/OpenSSL-hostname-validation/OpenSSLMissingVerifyCallback.ql
@@ -1,0 +1,155 @@
+/**
+ * @name OpenSSLMissingCNCheck
+ * @kind problem
+ * @problem.severity recommendation
+ * @id cpp/openssl-missing-verify-callback
+ * @tags security
+ *       external/cwe/cwe-273
+ *
+ * The default `verify_callback` https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_verify.html
+ * does not compare CN/hostnames so a TLS client can be MITMed.
+ *
+ * There are multiple stategies for verifying server certificates so this query assists with code
+ * review but does not accurately find vulnerabilities, false positives are likely.
+ *
+ * False negatives include using verify_callback to ignore verification, such as always returning
+ * a 1 without checking `preverify_ok`.
+ */
+
+import cpp
+import semmle.code.cpp.dataflow.TaintTracking
+
+class SslSetVerifyFunctionCall extends FunctionCall {
+  SslSetVerifyFunctionCall() { this.getTarget().hasName("SSL_set_verify") }
+}
+
+class SslCtxSetVerifyFunctionCall extends FunctionCall {
+  SslCtxSetVerifyFunctionCall() { this.getTarget().hasName("SSL_CTX_set_verify") }
+}
+
+class SslLikeSetVerifyFunctionCall extends FunctionCall {
+  SslLikeSetVerifyFunctionCall() {
+    this instanceof SslCtxSetVerifyFunctionCall or
+    this instanceof SslSetVerifyFunctionCall
+  }
+}
+
+class SslSet1HostFunctionCall extends FunctionCall {
+  SslSet1HostFunctionCall() { this.getTarget().hasName("SSL_set1_host") }
+}
+
+class SslCtxSetCertVerifyCallbackFunctionCall extends FunctionCall {
+  SslCtxSetCertVerifyCallbackFunctionCall() {
+    this.getTarget().hasName("SSL_CTX_set_cert_verify_callback")
+  }
+}
+
+class SslLikeCheckHostnameFunctionCall extends FunctionCall {
+  SslLikeCheckHostnameFunctionCall() {
+    this instanceof SslSet1HostFunctionCall or
+    this instanceof SslCtxSetCertVerifyCallbackFunctionCall
+  }
+}
+
+class SslPointerVariable extends Variable {
+  SslPointerVariable() { this.hasDefinition() and this.getUnderlyingType().hasName("SSL *") }
+}
+
+class SslCtxPointerVariable extends Variable {
+  SslCtxPointerVariable() { this.hasDefinition() and this.getUnderlyingType().hasName("SSL_CTX *") }
+}
+
+class SslLikePointerVariable extends Variable {
+  SslLikePointerVariable() {
+    this instanceof SslPointerVariable or
+    this instanceof SslCtxPointerVariable
+  }
+}
+
+class SslCtxNewClientFunctionCall extends FunctionCall {
+  SslCtxNewClientFunctionCall() {
+    this.getTarget().hasName("SSL_CTX_new") and
+    exists(FunctionCall fc |
+      fc.getTarget().getQualifiedName().matches("%_client_method") and
+      TaintTracking::localTaint(DataFlow::exprNode(fc), DataFlow::exprNode(this.getArgument(0)))
+    )
+  }
+}
+
+predicate sslPointerTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
+  // Propagate the taint from SSL <-> SSL_CTX.
+  exists(SslLikePointerVariable ctx, FunctionCall fc |
+    pred.asExpr() = ctx.getAnAccess() and
+    pred.asExpr() = fc.getArgument(0) and
+    succ.asExpr() = fc and
+    // Simple to go back and forth.
+    (fc.getTarget().hasName("SSL_new") or fc.getTarget().hasName("SSL_get_SSL_CTX"))
+  )
+  or
+  // Propagate the taint from argument to parameter use.
+  exists(FunctionCall fc, Expr arg, Parameter p, int i |
+    p = fc.getTarget().getAParameter() and
+    i = p.getIndex() and
+    arg = fc.getArgument(i) and
+    arg = pred.asExpr() and
+    succ.asExpr() = p.getAnAccess()
+  )
+}
+
+class SslCtxSetVerifyConfiguration extends TaintTracking::Configuration {
+  SslCtxSetVerifyConfiguration() { this = "SslCtxSetVerifyConfiguration" }
+
+  override predicate isSource(DataFlow::Node node) {
+    node.asExpr() instanceof SslCtxNewClientFunctionCall
+  }
+
+  override predicate isSink(DataFlow::Node node) {
+    // False positives can be reduced by checking that argument(1) is not VERIFY_NONE.
+    // This may lead to broader false negatives where code mistakenly sets VERIFY_NONE.
+    exists(SslLikeSetVerifyFunctionCall fc | node.asExpr() = fc.getArgument(0))
+  }
+
+  override predicate isAdditionalTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
+    sslPointerTaintStep(pred, succ)
+  }
+}
+
+class SslCtxCheckHostnameConfiguration extends TaintTracking::Configuration {
+  SslCtxCheckHostnameConfiguration() { this = "SslCtxCheckHostnameConfiguration" }
+
+  override predicate isSource(DataFlow::Node node) {
+    node.asExpr() instanceof SslCtxNewClientFunctionCall
+  }
+
+  override predicate isSink(DataFlow::Node node) {
+    exists(SslLikeCheckHostnameFunctionCall fc | node.asExpr() = fc.getArgument(0))
+  }
+
+  override predicate isAdditionalTaintStep(DataFlow::Node pred, DataFlow::Node succ) {
+    sslPointerTaintStep(pred, succ)
+  }
+}
+
+predicate flowsToSetVerify(FunctionCall ctx, FunctionCall fc) {
+  exists(SslCtxSetVerifyConfiguration conf |
+    conf.hasFlow(DataFlow::exprNode(ctx), DataFlow::exprNode(fc.getArgument(0)))
+  )
+}
+
+predicate flowsToCheckHostname(FunctionCall ctx) {
+  exists(SslCtxCheckHostnameConfiguration conf, FunctionCall fc |
+    conf.hasFlow(DataFlow::exprNode(ctx), DataFlow::exprNode(fc.getArgument(0)))
+  )
+}
+
+from FunctionCall ctx, FunctionCall fc
+where
+  flowsToSetVerify(ctx, fc) and
+  not flowsToCheckHostname(ctx) and
+  // Empty verify callback (this will not check CN).
+  // False positives include intentional skipped verification and any
+  // additional custom checking via accessing the peer certificate post-handshake.
+  fc.getArgument(2).getValue() = "0"
+select ctx,
+  "may be a client context without hostname verification because SSL_set1_host " +
+    "and other indicators of leaf cert hostname checking are missing", fc

--- a/CodeQL_Queries/cpp/OpenSSL-hostname-validation/OpenSSLMissingVerifyCallback.ql
+++ b/CodeQL_Queries/cpp/OpenSSL-hostname-validation/OpenSSLMissingVerifyCallback.ql
@@ -20,30 +20,10 @@
 
 import cpp
 import semmle.code.cpp.dataflow.TaintTracking
-
-class SslSetVerifyFunctionCall extends FunctionCall {
-  SslSetVerifyFunctionCall() { this.getTarget().hasName("SSL_set_verify") }
-}
-
-class SslCtxSetVerifyFunctionCall extends FunctionCall {
-  SslCtxSetVerifyFunctionCall() { this.getTarget().hasName("SSL_CTX_set_verify") }
-}
-
-class SslLikeSetVerifyFunctionCall extends FunctionCall {
-  SslLikeSetVerifyFunctionCall() {
-    this instanceof SslCtxSetVerifyFunctionCall or
-    this instanceof SslSetVerifyFunctionCall
-  }
-}
+import OpenSSLVerify
 
 class SslSet1HostFunctionCall extends FunctionCall {
   SslSet1HostFunctionCall() { this.getTarget().hasName("SSL_set1_host") }
-}
-
-class SslCtxSetCertVerifyCallbackFunctionCall extends FunctionCall {
-  SslCtxSetCertVerifyCallbackFunctionCall() {
-    this.getTarget().hasName("SSL_CTX_set_cert_verify_callback")
-  }
 }
 
 class SslLikeCheckHostnameFunctionCall extends FunctionCall {

--- a/CodeQL_Queries/cpp/OpenSSL-hostname-validation/OpenSSLPreverifyIgnored.ql
+++ b/CodeQL_Queries/cpp/OpenSSL-hostname-validation/OpenSSLPreverifyIgnored.ql
@@ -1,0 +1,61 @@
+/**
+ * @name OpenSSLPreverifyIgnored
+ * @kind problem
+ * @problem.severity recommendation
+ * @id cpp/openssl-preverify-ignored
+ * @tags security
+ *       external/cwe/cwe-273
+ *
+ * The `preverified` variable must be checked in verify_callbacks.
+ *
+ * False positives include callbacks used when certificate checking is intentionally
+ * bypassed or when the checking is performed on client certificates.
+ */
+
+import cpp
+
+class SslSetVerifyFunctionCall extends FunctionCall {
+  SslSetVerifyFunctionCall() { this.getTarget().hasName("SSL_set_verify") }
+}
+
+class SslCtxSetVerifyFunctionCall extends FunctionCall {
+  SslCtxSetVerifyFunctionCall() { this.getTarget().hasName("SSL_CTX_set_verify") }
+}
+
+class SslCtxSetCertVerifyCallbackFunctionCall extends FunctionCall {
+  SslCtxSetCertVerifyCallbackFunctionCall() {
+    this.getTarget().hasName("SSL_CTX_set_cert_verify_callback")
+  }
+}
+
+class SetVerifyCallbackFunctionCall extends FunctionCall {
+  SetVerifyCallbackFunctionCall() { this.getTarget().hasName("set_verify_callback") }
+}
+
+class CallbackArg extends Expr {
+  CallbackArg() {
+    exists(SetVerifyCallbackFunctionCall fc | this = fc.getArgument(0)) or
+    exists(SslCtxSetCertVerifyCallbackFunctionCall fc | this = fc.getArgument(1)) or
+    exists(SslCtxSetVerifyFunctionCall fc | this = fc.getArgument(2)) or
+    exists(SslSetVerifyFunctionCall fc | this = fc.getArgument(2))
+  }
+}
+
+class CallbackFunc extends Function {
+  CallbackFunc() {
+    exists(CallbackArg arg |
+      // False negatives include lambdas and any allocation expression.
+      this = arg.getAChild().(FunctionAccess).getTarget() or
+      this = arg.(FunctionAccess).getTarget()
+    )
+  }
+}
+
+predicate noPreverifyAccess(Function f) {
+  // False negatives include the variable being accessed but not influencing the return.
+  not exists(VariableAccess va | va = f.getParameter(0).getAnAccess())
+}
+
+from CallbackFunc f
+where noPreverifyAccess(f)
+select f, "is used as a certificate verify callback and does not use the preverified variable"

--- a/CodeQL_Queries/cpp/OpenSSL-hostname-validation/OpenSSLPreverifyIgnored.ql
+++ b/CodeQL_Queries/cpp/OpenSSL-hostname-validation/OpenSSLPreverifyIgnored.ql
@@ -13,20 +13,7 @@
  */
 
 import cpp
-
-class SslSetVerifyFunctionCall extends FunctionCall {
-  SslSetVerifyFunctionCall() { this.getTarget().hasName("SSL_set_verify") }
-}
-
-class SslCtxSetVerifyFunctionCall extends FunctionCall {
-  SslCtxSetVerifyFunctionCall() { this.getTarget().hasName("SSL_CTX_set_verify") }
-}
-
-class SslCtxSetCertVerifyCallbackFunctionCall extends FunctionCall {
-  SslCtxSetCertVerifyCallbackFunctionCall() {
-    this.getTarget().hasName("SSL_CTX_set_cert_verify_callback")
-  }
-}
+import OpenSSLVerify
 
 class SetVerifyCallbackFunctionCall extends FunctionCall {
   SetVerifyCallbackFunctionCall() { this.getTarget().hasName("set_verify_callback") }

--- a/CodeQL_Queries/cpp/OpenSSL-hostname-validation/OpenSSLVerify.qll
+++ b/CodeQL_Queries/cpp/OpenSSL-hostname-validation/OpenSSLVerify.qll
@@ -1,0 +1,26 @@
+import cpp
+
+/** 
+ * Common utilities for OpenSSL certificate verification.
+ */
+
+class SslSetVerifyFunctionCall extends FunctionCall {
+  SslSetVerifyFunctionCall() { this.getTarget().hasName("SSL_set_verify") }
+}
+
+class SslCtxSetVerifyFunctionCall extends FunctionCall {
+  SslCtxSetVerifyFunctionCall() { this.getTarget().hasName("SSL_CTX_set_verify") }
+}
+
+class SslLikeSetVerifyFunctionCall extends FunctionCall {
+  SslLikeSetVerifyFunctionCall() {
+    this instanceof SslCtxSetVerifyFunctionCall or
+    this instanceof SslSetVerifyFunctionCall
+  }
+}
+
+class SslCtxSetCertVerifyCallbackFunctionCall extends FunctionCall {
+  SslCtxSetCertVerifyCallbackFunctionCall() {
+    this.getTarget().hasName("SSL_CTX_set_cert_verify_callback")
+  }
+}

--- a/CodeQL_Queries/cpp/OpenSSL-hostname-validation/README.md
+++ b/CodeQL_Queries/cpp/OpenSSL-hostname-validation/README.md
@@ -1,0 +1,25 @@
+# Finding OpenSSL hostname verification bugs
+
+These queries help with bug hunting the [SSL-Conservatory style](https://github.com/iSECPartners/ssl-conservatory) bugs.
+
+## Missing verify callback
+
+A SSL/TLS client can choose from several server certificate verification strategies. One required step is to verify the certificate CN/SAN matches the intended host.
+
+A common way to implement this checking is with a callback set with `SSL_CTX_set_verify` or `SSL_CTX_set_cert_verify_callback`. Thus if `SSL_CTX_set_verify` is used without a callback set it is possible hostname validation does not occur.
+
+False positives include hostname verification strategies where the peer certificate is inspected before sending data over the socket.
+
+## Missing verify callback within Boost ASIO
+
+This is very similar to the above situation. Boost's ASIO library wraps several OpenSSL APIs. Without using `set_verify_callback` the code most likely fails to verify the server certificate hostname.
+
+The percision of this query is much higher.
+
+# Verify callback preverified ignored
+
+Finally in the verify callback method mentioned above, one parameter is a `preverified` result. This is the result of OpenSSL checking various x509 fields, such as expiry time, and verifying a trust chain from leaf cert to a root configured for the context.
+
+A callback can still be correct and not use this value, for example it can reimplement the verification.
+
+There are lots of instances where this function body looks like `{ return 1; }` meaning it ignores the pre-verification and also does not check the hostname.


### PR DESCRIPTION
Hello SecurityLab!

These queries are meant for bug-hunting only. I found that it's extremely difficult to bring these to a state where they can be considered for `ql`. However, they do help greatly in preforming code review, and they do find good bugs!