### PR TITLE
add labels async to internal issue

### DIFF
--- a/.github/actions/replicate/replicate.ts
+++ b/.github/actions/replicate/replicate.ts
@@ -114,6 +114,13 @@ export const createInternalIssue = async (payload: WebhookPayload, issue: Issue)
         })        
         internal_ref = issueResponse.data.number
         core.debug(`issue created: ${internal_ref}`)
+        const labelsResponse = await octokit.issues.addLabels( {
+            owner,
+            repo,
+            issue_number: internal_ref,
+            labels: issue.labels
+        })
+        core.debug(`Labels addition result: ${labelsResponse.status} ${(labelsResponse.status==200)? "OK" : "FAILED"}`)
 
         const issueCommentResponse1 = await octokit.issues.createComment({
             owner,


### PR DESCRIPTION
Setting the labels at issue creation does not work :( 
So the workaround is to create them async, once the issue is created, with an additional call to `addLabels`  