### PR TITLE
The condition is redundant and should be removed.

### DIFF
--- a/CodeQL_Queries/cpp/Chrome/callbacks.qll
+++ b/CodeQL_Queries/cpp/Chrome/callbacks.qll
@@ -104,7 +104,6 @@ predicate reach(Function f, Function g) {
       else
         overrides*(g, gc.getTarget())
       |
-      g = gc.getTarget() and
       gc.getEnclosingFunction() = f
     ) or
     exists(CallbackSinks sink | sink.getEnclosingCallable() = f and


### PR DESCRIPTION
@m-y-mo 

The reach function will stop at the virtual function call, not expected behavior.
