### PR TITLE
fix stripType() cannot be resolved for type Locatable bug in bindings.qll

### DIFF
--- a/CodeQL_Queries/cpp/Chrome/bindings.qll
+++ b/CodeQL_Queries/cpp/Chrome/bindings.qll
@@ -11,7 +11,7 @@ class StrongBinding extends ClassTemplateInstantiation {
   }
   
   Type getBindingType() {
-    result = this.getTemplateArgument(0).stripType()
+    result = this.getTemplateArgument(0).(Type).stripType()
   }
 }
 
@@ -21,7 +21,7 @@ class Binding extends ClassTemplateInstantiation {
   }
   
   Type getBindingType() {
-    result = this.getTemplateArgument(0).stripType()
+    result = this.getTemplateArgument(0).(Type).stripType()
   }
 }
 
@@ -32,7 +32,7 @@ class MojoReceiver extends ClassTemplateInstantiation {
   }
   
   Type getBindingType() {
-    result = this.getTemplateArgument(0).stripType()
+    result = this.getTemplateArgument(0).(Type).stripType()
   }
 }
 

--- a/CodeQL_Queries/cpp/Chrome/qlpack.yml
+++ b/CodeQL_Queries/cpp/Chrome/qlpack.yml
@@ -1,0 +1,3 @@
+name: chrome_ql
+version: 0.0.0
+libraryPathDependencies: codeql-cpp


### PR DESCRIPTION
@m-y-mo 
The current version of binding.qll will report an error. I have provided a simple fix. Please review it.