### PR TITLE
Underscores are apparently no longer allowed in pack names

### DIFF
--- a/CodeQL_Queries/cpp/Chrome/qlpack.yml
+++ b/CodeQL_Queries/cpp/Chrome/qlpack.yml
@@ -1,3 +1,3 @@
-name: chrome_ql
+name: chrome-ql
 version: 0.0.0
 libraryPathDependencies: codeql-cpp


### PR DESCRIPTION
This repo stopped working in VSCode. Apparently underscores are no longer allowed in pack names.