### PR TITLE
Add `swift` as a language option

### DIFF
--- a/.github/ISSUE_TEMPLATE/all-for-one.yml
+++ b/.github/ISSUE_TEMPLATE/all-for-one.yml
@@ -37,6 +37,7 @@ body:
         - Ruby
         - C/C++
         - C#
+        - Swift
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
This pull request adds the option to select "Swift" as a programming language when creating an issue in the `.github/ISSUE_TEMPLATE/all-for-one.yml` file.

* <a href="diffhunk://#diff-5378f11f5ea2ea3f5273e1e1916418a292717a569d7d0b867cfa288ca8c6f611R40">`.github/ISSUE_TEMPLATE/all-for-one.yml`</a>: Added "Swift" as an option for selecting a programming language when creating an issue.

ref https://github.com/github/securitylab/issues/802#issuecomment-1824325227