### PR TITLE
QLpacks update

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+{
+  "customizations": {
+    "codespaces": {
+      "extensions": [
+        "github.vscode-codeql"
+      ],
+      "settings": {
+        "codeQL.runningQueries.memory": 4096,
+        "codeQL.runningQueries.autoSave": true,
+        "CodeQL.canary.enabled": true
+      }
+    },
+    "vscode": {
+      "extensions": [
+        "github.vscode-codeql"
+      ],
+      "settings": {
+        "codeQL.runningQueries.memory": 4096,
+        "CodeQL.canary.enabled": true
+      },
+    }
+  },
+  "postCreateCommand": "",
+  "hostRequirements": {
+    "memory": "16gb"
+  }
+ }

--- a/CodeQL_Queries/README.md
+++ b/CodeQL_Queries/README.md
@@ -1,0 +1,19 @@
+To run the queries in this repository:
+1. Click the green "Code" button > Codespaces > Create a codespace on main. A new codespace will be created for you with VS Code CodeQL extension preinstalled.
+2. When the codespace finishes setting up, open the terminal, and find the path to the codeql binary (which comes preinstalled with the VS Code CodeQL extension) with the command:
+```bash
+find ~ -type f -name codeql -executable 2>/dev/null
+```
+It will most likely look similar to this:
+```
+/home/codespace/.vscode-remote/data/User/globalStorage/github.vscode-codeql/distribution1/codeql/codeql
+```
+3. Using the CodeQL binary, go to the language folder with the query you want to run `codeql pack install, for example:
+```bash
+cd cpp
+/home/codespace/.vscode-remote/data/User/globalStorage/github.vscode-codeql/distribution1/codeql/codeql pack install
+```
+This will install the CodeQL library files required to run the CodeQL queries.
+4. Press `Ctrl/Cmd + Shift + R` to reload the window to see syntax highlighting etc. 
+5. Check the README in the folder with the query you are interested in, and add the database listed in the README to your VS Code CodeQL extension.
+6. Open the query file you are interested in, right-click and choose `CodeQL: Run Query on selected database` from the dropdowns.

--- a/CodeQL_Queries/cpp/codeql-pack.lock.yml
+++ b/CodeQL_Queries/cpp/codeql-pack.lock.yml
@@ -1,0 +1,22 @@
+---
+lockVersion: 1.0.0
+dependencies:
+  codeql/cpp-all:
+    version: 0.12.11
+  codeql/dataflow:
+    version: 0.2.5
+  codeql/rangeanalysis:
+    version: 0.0.13
+  codeql/ssa:
+    version: 0.2.14
+  codeql/tutorial:
+    version: 0.2.14
+  codeql/typeflow:
+    version: 0.0.1
+  codeql/typetracking:
+    version: 0.2.14
+  codeql/util:
+    version: 0.2.14
+  codeql/xml:
+    version: 0.0.1
+compiled: false

--- a/CodeQL_Queries/cpp/qlpack.yml
+++ b/CodeQL_Queries/cpp/qlpack.yml
@@ -1,3 +1,4 @@
 name: codeql-demos-cpp
 version: 0.0.0
-libraryPathDependencies: codeql-cpp
+dependencies:
+  codeql/cpp-all: ^0.12.0

--- a/CodeQL_Queries/csharp/codeql-pack.lock.yml
+++ b/CodeQL_Queries/csharp/codeql-pack.lock.yml
@@ -1,0 +1,18 @@
+---
+lockVersion: 1.0.0
+dependencies:
+  codeql/controlflow:
+    version: 0.0.4
+  codeql/csharp-all:
+    version: 0.7.5
+  codeql/dataflow:
+    version: 0.0.4
+  codeql/mad:
+    version: 0.1.5
+  codeql/ssa:
+    version: 0.1.5
+  codeql/tutorial:
+    version: 0.1.5
+  codeql/util:
+    version: 0.1.5
+compiled: false

--- a/CodeQL_Queries/csharp/qlpack.yml
+++ b/CodeQL_Queries/csharp/qlpack.yml
@@ -1,3 +1,4 @@
 name: codeql-demos-csharp
 version: 0.0.0
-libraryPathDependencies: codeql-csharp
+dependencies:
+  codeql/csharp-all: ^0.7.3

--- a/CodeQL_Queries/java/codeql-pack.lock.yml
+++ b/CodeQL_Queries/java/codeql-pack.lock.yml
@@ -1,0 +1,20 @@
+---
+lockVersion: 1.0.0
+dependencies:
+  codeql/dataflow:
+    version: 0.0.4
+  codeql/java-all:
+    version: 0.7.5
+  codeql/mad:
+    version: 0.1.5
+  codeql/regex:
+    version: 0.1.5
+  codeql/ssa:
+    version: 0.1.5
+  codeql/tutorial:
+    version: 0.1.5
+  codeql/typetracking:
+    version: 0.1.5
+  codeql/util:
+    version: 0.1.5
+compiled: false

--- a/CodeQL_Queries/java/qlpack.yml
+++ b/CodeQL_Queries/java/qlpack.yml
@@ -1,3 +1,4 @@
 name: codeql-demos-java
 version: 0.0.0
-libraryPathDependencies: codeql-java
+dependencies:
+  codeql/java-all: ^0.7.0

--- a/CodeQL_Queries/javascript/codeql-pack.lock.yml
+++ b/CodeQL_Queries/javascript/codeql-pack.lock.yml
@@ -1,0 +1,6 @@
+---
+lockVersion: 1.0.0
+dependencies:
+  codeql/javascript-all:
+    version: 0.3.0
+compiled: false

--- a/CodeQL_Queries/javascript/qlpack.yml
+++ b/CodeQL_Queries/javascript/qlpack.yml
@@ -1,3 +1,5 @@
 name: codeql-demos-javascript
 version: 0.0.0
-libraryPathDependencies: codeql-javascript
+dependencies:
+  codeql/javascript-all: 0.3.0
+


### PR DESCRIPTION
This PR updates QLpacks to use the new configuration, with specific library versions, adds a devcontainer which will automatically install the VS Code CodeQL extension, and adds instructions on how to run queries in those folders.

The QL packs currently use legacy configuration, and need to be updated for queries to run. 

The queries also require specific library versions. It's hard to guess which are the right ones, so I updated the QL packs with versions that are over 2 years old, since most queries use the old dataflow API, which is only available in the old library versions. I tested some of the queries, and some run fine, some are not displayed properly in VS Code CodeQL extension, probably due to changes to the extension itself, or the CodeQL version that comes prebundled with the extension. This is my best attempt at making them work. 